### PR TITLE
Unbreaking compilation errors

### DIFF
--- a/thrust/system/cuda/detail/bulk/malloc.hpp
+++ b/thrust/system/cuda/detail/bulk/malloc.hpp
@@ -63,11 +63,7 @@ inline __device__ T *on_chip_cast(T *ptr)
 namespace detail
 {
 
-#ifdef __HIP_PLATFORM_NVCC__
 HIP_DYNAMIC_SHARED( int, s_data_segment_begin)
-#else
-extern  int s_data_segment_begin[];
-#endif
 
 class os
 {
@@ -474,19 +470,12 @@ class singleton_on_chip_allocator
 }; // end singleton_on_chip_allocator
 
 // put the object in an anonymous namespace so that non-CUDA compilers don't complain about multiple definitions
-#ifdef __HIP_PLATFORM_NVCC__
 namespace
 {
 
 __shared__  uninitialized<singleton_on_chip_allocator> s_on_chip_allocator;
 
 } // end anon namespace
-#else
-namespace
-{
-uninitialized<singleton_on_chip_allocator> s_on_chip_allocator;
-} // end anon namespace
-#endif
 
 inline __device__ void init_on_chip_malloc(size_t max_data_segment_size)
 {


### PR DESCRIPTION
Let the dynamic shared memory variables declarations for HIP backend to be the same as for CUDA backend, since the current version of HIP supports exactly the same notation. This PR fixes https://github.com/ROCmSoftwarePlatform/Thrust/issues/27 .

